### PR TITLE
Fix return for missing permissions

### DIFF
--- a/events/message.js
+++ b/events/message.js
@@ -14,7 +14,7 @@ module.exports = class {
     if (message.author.bot) return;
 
     // Cancel any attempt to execute commands if the bot cannot respond to the user.
-    if (message.guild.me.permissionsIn(message.channel).missing("SEND_MESSAGES")) return;
+    if (!message.channel.permissionsFor(message.guild.me).missing("SEND_MESSAGES")) return;
     
     // Grab the settings for this server from the PersistentCollection
     // If there is no guild, get default conf (DMs)


### PR DESCRIPTION
Fixes line 17, after testing without fix it would ignore all messages, regardless if the bot could read in the channel or not.

Changes from:
``if (message.guild.me.permissionsIn(message.channel).missing("SEND_MESSAGES")) return;``
To
``if (!message.channel.permissionsFor(message.guild.me).missing("SEND_MESSAGES")) return;``